### PR TITLE
Remove System.out.println(jsonResponse);

### DIFF
--- a/src/main/java/org/jmusixmatch/MusixMatch.java
+++ b/src/main/java/org/jmusixmatch/MusixMatch.java
@@ -297,8 +297,6 @@ public class MusixMatch {
 		StatusCode statusCode;
 		Gson gson = new Gson();
 
-		System.out.println(jsonResponse);
-
 		ErrorMessage errMessage = gson.fromJson(jsonResponse,
 				ErrorMessage.class);
 		int responseCode = errMessage.getMessageContainer().getHeader()


### PR DESCRIPTION
When having an exception, it will print the json response. Would not be ideal for the api to force the print like that.