### PR TITLE
Fix error message serialization

### DIFF
--- a/src/main/java/org/jmusixmatch/entity/error/ErrorMessageContainer.java
+++ b/src/main/java/org/jmusixmatch/entity/error/ErrorMessageContainer.java
@@ -1,12 +1,14 @@
 package org.jmusixmatch.entity.error;
 
-import com.google.gson.annotations.SerializedName;
+import java.util.List;
 
 import org.jmusixmatch.entity.Header;
 
+import com.google.gson.annotations.SerializedName;
+
 public class ErrorMessageContainer {
 	@SerializedName("body")
-	private String body;
+	private List<String> body;
 
 	@SerializedName("header")
 	private Header header;
@@ -19,11 +21,11 @@ public class ErrorMessageContainer {
 		this.header = header;
 	}
 
-	public void setBody(String body) {
+	public void setBody(List<String> body) {
 		this.body = body;
 	}
 
-	public String getBody() {
+	public List<String> getBody() {
 		return body;
 	}
 }


### PR DESCRIPTION
I guess musixmatch changed the error message response recently. An error message response currently looks like this:

```
{
	"message": {
		"header": {
			"status_code": 404,
			"execute_time": 0.0067391395568848
		},
		**_"body": []_**
	}
}
```
The "body" element was previously serialized as a string which caused an IllegalStateException to be thrown when an HTTP 404 status was returned (for example when we're trying to get a track with an inexisting ID).
